### PR TITLE
python: fix missing blank in freeze-importlib PROVIDES

### DIFF
--- a/recipes/python/python.inc
+++ b/recipes/python/python.inc
@@ -239,7 +239,7 @@ AUTO_PACKAGE_UTILS_RDEPENDS = "python${MAJOR_PV}"
 # Provide version dependent packages to ensure the
 # right version is used to build for target
 PROVIDES_${PN}-pgen:>native = " ${PN}${MAJOR_PV}-pgen"
-PROVIDES_${PN}-freeze-importlib:>native += "${PN}${MAJOR_PV}-freeze-importlib"
+PROVIDES_${PN}-freeze-importlib:>native = " ${PN}${MAJOR_PV}-freeze-importlib"
 
 # Add symlinked files to each util package
 FILES_${PN}-2to3 += "${bindir}/2to3-${MAJOR_PV}.${MINOR_PV} ${bindir}/2to3"


### PR DESCRIPTION
The line to provide a version dependant package for
python-freeze-importlib lacks a blank space to separate it from heading
provides, which causes build failures cases where the provides line is
parsed or non-empty.
